### PR TITLE
Fix action checker systemd background start

### DIFF
--- a/py_scripts/action_checker/action_checker.py
+++ b/py_scripts/action_checker/action_checker.py
@@ -118,7 +118,10 @@ StandardError=journal
         print("Navigate to a directory with an open PR before running this script")
         return
 
-    subprocess.run(["systemctl", "--user", "start", "pr-check-monitor.service"], check=True)
+    subprocess.run(
+        ["systemctl", "--user", "start", "--no-block", "pr-check-monitor.service"],
+        check=True,
+    )
 
     print("Started systemd service: pr-check-monitor.service")
     print("Check status: systemctl --user status pr-check-monitor.service")


### PR DESCRIPTION
## Summary
- ensure the systemd service starts asynchronously

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68568ecaea148320b2b15f167339ff08